### PR TITLE
Add support to elastic ips

### DIFF
--- a/altimeter/aws/resource/ec2/elastic_ip.py
+++ b/altimeter/aws/resource/ec2/elastic_ip.py
@@ -1,0 +1,54 @@
+"""Resource for ElasticIPs"""
+from typing import Type
+
+from botocore.client import BaseClient
+
+from altimeter.aws.resource.resource_spec import ListFromAWSResult
+from altimeter.aws.resource.ec2 import EC2ResourceSpec
+from altimeter.core.graph.field.scalar_field import ScalarField
+from altimeter.core.graph.field.tags_field import TagsField
+from altimeter.core.graph.schema import Schema
+
+
+class ElasticIPResourceSpec(EC2ResourceSpec):
+    """Resource for ElasticIPs"""
+
+    type_name = "elastic-ip"
+    schema = Schema(
+        ScalarField("PublicIp"),
+        ScalarField("AllocationId", optional=True),
+        ScalarField("AssociationId", optional=True),
+        ScalarField("Domain"),
+        ScalarField("InstanceId", optional=True),
+        ScalarField("NetworkInterfaceId", optional=True),
+        ScalarField("NetworkInterfaceOwnerId", optional=True),
+        ScalarField("PrivateIpAddress", optional=True),
+        ScalarField("PublicIpv4Pool", optional=True),
+        ScalarField("NetworkBorderGroup", optional=True),
+        ScalarField("CustomerOwnedIp", optional=True),
+        ScalarField("CustomerOwnedIpv4Pool", optional=True),
+        ScalarField("CarrierIp", optional=True),
+        TagsField(),
+    )
+
+    @classmethod
+    def list_from_aws(
+        cls: Type["ElasticIPResourceSpec"],
+        client: BaseClient, account_id: str,
+        region: str
+    ) -> ListFromAWSResult:
+        """Return a dict with the following format:
+
+            {'elastic_ip_arn_1': {elastic_ip_1},
+             'elastic_ip_arn2': {elastic_ip_2},
+             ...}
+        """
+        elastic_ips = {}
+        resp = client.describe_addresses()
+        for elastic_ip in resp.get("Addresses", []):
+            resource_id = elastic_ip["PublicIp"].replace(".", "-")
+            resource_arn = cls.generate_arn(
+                account_id=account_id, region=region, resource_id=resource_id
+            )
+            elastic_ips[resource_arn] = elastic_ip
+        return ListFromAWSResult(resources=elastic_ips)

--- a/altimeter/aws/scan/settings.py
+++ b/altimeter/aws/scan/settings.py
@@ -26,6 +26,7 @@ from altimeter.aws.resource.ec2.vpc import VPCResourceSpec
 from altimeter.aws.resource.ec2.vpc_endpoint import VpcEndpointResourceSpec
 from altimeter.aws.resource.ec2.vpc_endpoint_service import VpcEndpointServiceResourceSpec
 from altimeter.aws.resource.ec2.vpc_peering_connection import VPCPeeringConnectionResourceSpec
+from altimeter.aws.resource.ec2.elastic_ip import ElasticIPResourceSpec
 from altimeter.aws.resource.elbv1.load_balancer import ClassicLoadBalancerResourceSpec
 from altimeter.aws.resource.elbv2.load_balancer import LoadBalancerResourceSpec
 from altimeter.aws.resource.elbv2.target_group import TargetGroupResourceSpec
@@ -95,6 +96,7 @@ DEFAULT_RESOURCE_SPEC_CLASSES: Tuple[Type[AWSResourceSpec], ...] = (
     VPCResourceSpec,
     VpcEndpointResourceSpec,
     VpcEndpointServiceResourceSpec,
+    ElasticIPResourceSpec,
 )
 
 INFRA_RESOURCE_SPEC_CLASSES: Tuple[Type[AWSResourceSpec], ...] = (

--- a/tests/unit/altimeter/aws/resource/ec2/test_ec2_elastic_ip.py
+++ b/tests/unit/altimeter/aws/resource/ec2/test_ec2_elastic_ip.py
@@ -1,0 +1,93 @@
+import unittest
+
+import boto3
+from moto import mock_ec2
+
+from altimeter.aws.resource.ec2.elastic_ip import ElasticIPResourceSpec
+from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.core.graph.links import LinkCollection, ResourceLink, SimpleLink
+from altimeter.core.resource.resource import Resource
+
+
+class TestElasticIPSchema(unittest.TestCase):
+    @mock_ec2
+    def test_scan_vpc_domain(self):
+        self.maxDiff = None
+        account_id = "123456789012"
+        region_name = "us-east-1"
+
+        session = boto3.Session()
+
+        ec2_client = session.client("ec2", region_name=region_name)
+        allocation = ec2_client.allocate_address(Domain="vpc")
+        allocation_id = allocation["AllocationId"]
+        public_ip = allocation["PublicIp"]
+        arn = "arn:aws:ec2:us-east-1:123456789012:elastic-ip/" + public_ip.replace(".", "-")
+
+        scan_accessor = AWSAccessor(
+            session=session,
+            account_id=account_id,
+            region_name=region_name
+        )
+        resources = ElasticIPResourceSpec.scan(scan_accessor)
+
+        expected_resources = [
+            Resource(
+                resource_id=arn,
+                type="aws:ec2:elastic-ip",
+                link_collection=LinkCollection(
+                    simple_links=(
+                        SimpleLink(pred="public_ip", obj=public_ip),
+                        SimpleLink(pred="allocation_id", obj=allocation_id),
+                        SimpleLink(pred="domain", obj="vpc"),
+                        SimpleLink(pred="instance_id", obj=""),
+                        SimpleLink(pred="network_interface_id", obj=""),
+                    ),
+                    resource_links=(
+                        ResourceLink(pred="account", obj="arn:aws::::account/123456789012"),
+                        ResourceLink(pred="region", obj="arn:aws:::123456789012:region/us-east-1"),
+                    ),
+                ),
+            )
+        ]
+        self.assertEqual(resources, expected_resources)
+
+    @mock_ec2
+    def test_scan_non_vpc_domain(self):
+        self.maxDiff = None
+        account_id = "123456789012"
+        region_name = "us-east-1"
+
+        session = boto3.Session()
+
+        ec2_client = session.client("ec2", region_name=region_name)
+        allocation = ec2_client.allocate_address()
+        public_ip = allocation["PublicIp"]
+        arn = "arn:aws:ec2:us-east-1:123456789012:elastic-ip/" + public_ip.replace(".", "-")
+
+        scan_accessor = AWSAccessor(
+            session=session,
+            account_id=account_id,
+            region_name=region_name
+        )
+        resources = ElasticIPResourceSpec.scan(scan_accessor)
+
+        expected_resources = [
+            Resource(
+                resource_id=arn,
+                type="aws:ec2:elastic-ip",
+                link_collection=LinkCollection(
+                    simple_links=(
+                        SimpleLink(pred="public_ip", obj=public_ip),
+                        SimpleLink(pred="domain", obj="standard"),
+                        SimpleLink(pred="instance_id", obj=""),
+                        SimpleLink(pred="network_interface_id", obj=""),
+                    ),
+                    resource_links=(
+                        ResourceLink(pred="account", obj="arn:aws::::account/123456789012"),
+                        ResourceLink(pred="region", obj="arn:aws:::123456789012:region/us-east-1"),
+                    ),
+                ),
+            )
+        ]
+        self.assertEqual(resources, expected_resources)


### PR DESCRIPTION
This PR adds support for gathering information about the elastic IP's of an AWS account.
Concretely, it adds a new AWS resource called `elastic-ip` that holds the information returned by the [corresponding boto3 method](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_addresses.html#).

The documentation does not specify which fields of an Elastic IP are mandatory, so I deduced which ones are from the execution of some examples. That's not the best way of doing it, but from my point of view it's better than putting all of them optional.

The GitHub action that defines the build is not passing, but I prefer to not spend time in trying to fix it because it looks like it is not related to the code of this PR or our fork as it is also happening [upstream](https://github.com/tableau/altimeter/actions), so I prefer to wait until they fix it as the aim is to, eventually, send the modifications we make in the Adevinta fork upstream. 

In order to check the tests I added are passing you can run locally the following command:

```bash
pytest tests/unit/altimeter/aws/resource/ec2/test_ec2_elastic_ip.py  
``` 